### PR TITLE
Use the mobile API instead

### DIFF
--- a/gvacli.go
+++ b/gvacli.go
@@ -216,7 +216,7 @@ func (me *FlightInfos) PrepareDeparturesTable(f []Flight) [][]string {
 		dataDep = append(dataDep, []string{
 			dep.ScheduledDeparture.String(),
 			dep.PublicDeparture.String(),
-			dep.Airport,
+			fmt.Sprintf("%s (%s)", dep.Airport, dep.AirportCodeDestination),
 			flightIds,
 			dep.Company,
 			dep.Gate,
@@ -252,7 +252,7 @@ func (me *FlightInfos) PrepareArrivalsTable(f []Flight) [][]string {
 			arr.ScheduledArrival.String(),
 			arr.PublicArrival.String(),
 			arr.DepartureFromPreviousAirport.String(),
-			arr.Airport,
+			fmt.Sprintf("%s (%s)", arr.Airport, arr.AirportCode),
 			flightIds,
 			arr.Company,
 			arr.Carousel,


### PR DESCRIPTION
The only but substantial gain of changing the API being used is that the mobile one contains the aircraft registration. Personally I find this very useful so the change is kind of justified for me. Your call, I can keep this in a fork of mine if you want to leave stuff as it's today :)