### PR TITLE
Add an on-disk cache for FlightInfos objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Just a Go version of https://github.com/nbarrientos/gvacli for Linux, MacOS and 
 * `--arrivals`: Show arrivals (default)
 * `--code-shares`: Show code shares on flights
 * `--departures`: Show departures
+* `--no-cache`: Ignore the local cache and force a call to the API
 
 ## Screenshot
 

--- a/flightinfos.go
+++ b/flightinfos.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"sort"
@@ -18,10 +19,56 @@ type FlightInfos struct {
 		Arrivals   []Flight `json:"arrivals"`
 		Departures []Flight `json:"departures"`
 	} `json:"flights"`
+	cache_file_path string
+	cache_available bool
 }
 
-// GetData fetches flight data from the remote API
-func (me *FlightInfos) GetData() error {
+func NewFlightInfos() *FlightInfos {
+	c := FlightInfos{}
+	user_cache_dir, err := os.UserCacheDir()
+	if err != nil {
+		log.Printf("Unable to determine local user cache directory")
+		c.cache_available = false
+	}
+	cache_dir := fmt.Sprintf("%s/gvacli", user_cache_dir)
+
+	if _, err := os.Stat(cache_dir); os.IsNotExist(err) {
+		err := os.Mkdir(cache_dir, 0755)
+		if err != nil {
+			log.Printf("Unable to create cache directory")
+			c.cache_available = false
+		}
+	}
+	c.cache_available = true
+	c.cache_file_path = fmt.Sprintf("%s/flightinfos.json", cache_dir)
+	return &c
+}
+
+func (me *FlightInfos) cacheCanBeConsumed() bool {
+	if NoCache || !me.cache_available {
+		return false
+	}
+	if cache_info, err := os.Stat(me.cache_file_path); err == nil {
+		cache_age_seconds := time.Now().Sub(cache_info.ModTime()).Seconds()
+		if cache_info.Size() > 0 && cache_age_seconds < CacheTTLSeconds {
+			return true
+		}
+	}
+	return false
+}
+
+func (me *FlightInfos) cacheRead() ([]byte, error) {
+	return ioutil.ReadFile(me.cache_file_path)
+}
+
+func (me *FlightInfos) cacheWrite(data []byte) {
+	err := ioutil.WriteFile(me.cache_file_path, data, 0644)
+	if err != nil {
+		log.Printf("Unable to write cache file (%s)", err)
+	}
+}
+
+func (me *FlightInfos) getDataFromNetwork() ([]byte, error) {
 	cli := http.Client{
 		Timeout: time.Duration(APITimeout) * time.Second,
 	}
@@ -29,7 +76,7 @@ func (me *FlightInfos) GetData() error {
 	req, err := http.NewRequest(http.MethodPost, APIUrl, nil)
 	if err != nil {
 		fmt.Print(err)
-		return err
+		return nil, err
 	}
 
 	req.Header.Set("X-Requested-With", "XMLHttpRequest")
@@ -37,11 +84,33 @@ func (me *FlightInfos) GetData() error {
 	req.Header.Set("Content-type", "application/json")
 	res, err := cli.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer res.Body.Close()
 
 	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	if me.cache_available {
+		me.cacheWrite(body)
+	}
+	return body, nil
+}
+
+// GetData fetches flight data from the remote API or the local cache
+func (me *FlightInfos) GetData() error {
+	var body []byte
+	var err error
+	if me.cacheCanBeConsumed() {
+		body, err = me.cacheRead()
+		if err != nil {
+			body, err = me.getDataFromNetwork()
+		}
+	} else {
+		body, err = me.getDataFromNetwork()
+	}
+
 	if err != nil {
 		return err
 	}

--- a/gvacli.go
+++ b/gvacli.go
@@ -9,6 +9,7 @@ import (
 // Some useful timestamps and values
 var (
 	BigDelayMinutes	  float64 = 60
+	CacheTTLSeconds   float64 = 60
 	DisplayTimeFormat = "02/01 15:04"
 	FairDelayMinutes  float64 = 30
 	JSONTimeFormat    = "2006-01-02 15:04:05"
@@ -16,6 +17,7 @@ var (
 	APITimeout        int
 	Departures        bool
 	Arrivals          bool
+	NoCache           bool
 	ShowCodeShare     bool
 	ShowAllFlights    bool
 )
@@ -27,6 +29,7 @@ func init() {
 	flag.BoolVar(&Departures, "departures", false, "Show departures")
 	flag.BoolVar(&Arrivals, "arrivals", false, "Show arrivals")
 	flag.BoolVar(&ShowAllFlights, "all-flights", false, "Show all flights, despite of the status")
+	flag.BoolVar(&NoCache, "no-cache", false, "Ignored cached data")
 
 	flag.Parse()
 }
@@ -38,7 +41,7 @@ func main() {
 		Arrivals = true
 	}
 
-	info := FlightInfos{}
+	info := NewFlightInfos()
 	if err := info.GetData(); err != nil {
 		log.Fatalf("Unable to fetch data from remote API: %s", err)
 	}


### PR DESCRIPTION
A typical behaviour on my side is to take a look at the departures and when there's something abnormal with a given aircraft, search for all the flights (arrivals and departures) of the plane. For this I execute another call to `gvacli` that I feed to grep to search for the registration. This issues another unnecessary network call as the information is very unlikely to change in such a short period of time. 
Hence, adding a short-lived cache (60 seconds, currently hardcoded) is good for both the user (faster output) and the server (less unnecessary requests).

The patch adds a new command line option (--no-cache) to ignore the local cache, even if it's still fresh. My intention was to never fail hard if the cache cannot be generated/read/etc.

Multi OS compatibility is kept as os.UserCacheDir() is portable.

```shell
user@foo:~/dev/go-gvacli$ rm -rf /home/nacho/.cache/gvacli/*
user@foo:~/dev/go-gvacli$ strace -e trace=network ./go-gvacli 2>&1 | grep "htons(443)"
getpeername(3, {sa_family=AF_INET6, sin6_port=htons(443), inet_pton(AF_INET6, "2001:1600:4:11::4e", &sin6_addr), sin6_flowinfo=htonl(0), sin6_scope_id=0}, [112->28]) = 0
user@foo:~/dev/go-gvacli$ strace -e trace=network ./go-gvacli 2>&1 | grep "htons(443)"
user@foo:~/dev/go-gvacli$ sleep 60 && strace -e trace=network ./go-gvacli 2>&1 | grep "htons(443)"
getpeername(3, {sa_family=AF_INET6, sin6_port=htons(443), inet_pton(AF_INET6, "2001:1600:4:11::4e", &sin6_addr), sin6_flowinfo=htonl(0), sin6_scope_id=0}, [112->28]) = 0
user@foo:~/dev/go-gvacli$ strace -e trace=network ./go-gvacli 2>&1 | grep "htons(443)"
user@foo:~/dev/go-gvacli$
```