### PR TITLE
Reformat "Next Info" as "Delayed"

### DIFF
--- a/flightstatus.go
+++ b/flightstatus.go
@@ -24,6 +24,8 @@ func (me *FlightStatus) String() string {
 		return color.Primary.Sprintf(status)
 	case "Delayed":
 		return color.Danger.Sprintf(status)
+	case "Next Info":
+		return color.Danger.Sprintf("Delayed")
 	case "Cancelled":
 		return color.Error.Sprintf(status)
 	default:


### PR DESCRIPTION
Departures with status "Next Info" are departures that are officially
delayed for which the expected departure time is unknown. This status
comes with an expected time for more info that's available on the
NextPublicAdvice field.

I don't believe that the "Delayed" status ever applies to departures, it
seems to me that delayed departures have either:

 * An empty status and an expected (delayed) departure time.
 * "Next info" status, no expected departure time and NextPublicAdvice.

Ideally if the status is "Next Info" we should be printing
NextPublicAdvice somehere but for the time being translating "Next Info"
into "Delayed" is enough.